### PR TITLE
Validate proxy connectivity for accounts

### DIFF
--- a/youtube_reporter.py
+++ b/youtube_reporter.py
@@ -1,0 +1,38 @@
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+import requests
+from requests.exceptions import RequestException
+
+TEST_URL = "https://httpbin.org/ip"
+
+
+@dataclass
+class Proxy:
+    http: str
+    https: str
+
+
+@dataclass
+class Account:
+    username: str
+    proxy: Optional[Proxy] = None
+
+
+def check_proxy(proxy: Proxy) -> bool:
+    """Check whether a proxy is usable by issuing a lightweight request."""
+    try:
+        requests.get(TEST_URL, proxies={"http": proxy.http, "https": proxy.https}, timeout=5)
+        return True
+    except RequestException:
+        return False
+
+
+class YouTubeReporter:
+    def __init__(self, accounts: List[Account]):
+        self.accounts: List[Account] = []
+        for account in accounts:
+            if account.proxy and not check_proxy(account.proxy):
+                logging.error("Proxy failed for account %s", account.username)
+                continue
+            self.accounts.append(account)


### PR DESCRIPTION
## Summary
- add `check_proxy` utility to validate proxies via lightweight request
- filter out accounts with failing proxies during `YouTubeReporter` initialization and log errors

## Testing
- `python -m py_compile youtube_reporter.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b738dbae748328a6b8f97dfd6fdd96